### PR TITLE
Hotfix/shikemokumk

### DIFF
--- a/data/others/live2d/Live2Dtyrano.js
+++ b/data/others/live2d/Live2Dtyrano.js
@@ -12,6 +12,8 @@ if(browser == "chrome" || browser == "safari"){
     v_prefix = "Moz";
 }else if(browser =="opera"){
     v_prefix = "o";
+}else{
+    v_prefix = "webkit";
 }
 
 (function(window){

--- a/data/scenario/live2d/live2d.ks
+++ b/data/scenario/live2d/live2d.ks
@@ -313,14 +313,18 @@ tf.models = live2d_models;
 tf.array_models = [];
 var index=0;
 for (var name in live2d_models){
-	live2d_models[name]["name"] = name;
-    tf.array_models[index] = live2d_models[name];
-    index++;
+	if(live2d_models[name]){
+	    live2d_models[name]["name"] = name;
+        tf.array_models[index] = live2d_models[name];
+        index++;
+    }
 }
 
 tf.cnt_model = tf.array_models.length;
 
 [endscript]
+
+@jump target="*end" cond="tf.cnt_model==0"
 
 *point
 
@@ -383,5 +387,7 @@ tf.cnt_model = tf.array_models.length;
 [if exp="tf.i<tf.cnt_model"]
 @jump target="point"
 [endif]
+
+*end
 
 [endmacro]


### PR DESCRIPTION
Live2Dモデル未使用の画面でロードした時に発生する不具合を修正
iOSアプリ化で発生する不具合対応。

ゲーム中、Live2Dモデルが表示されている状態で
ロードした時にLive2Dオブジェクトが残る問題については
ティラノ本体側で対策を行いました。v455fで反映。
 